### PR TITLE
Add nightly test scripts

### DIFF
--- a/run-nightly.sh
+++ b/run-nightly.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+go get -u ./...
+go install
+eval $(ssh-agent)
+ssh-add id_test_cluster.rsa
+mkdir -p ~/.ssh
+for i in {1..7}; do
+    ssh-keyscan -H cockroach-denim-000$i.crdb.io >> ~/.ssh/known_hosts
+done
+
+curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach
+chmod +x cockroach
+
+roachperf denim put ./cockroach ./cockroach
+
+cd artifacts
+roachperf denim test nightly

--- a/teamcity-nightly.sh
+++ b/teamcity-nightly.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "${TEST_CLUSTER_SSH_KEY}" > id_test_cluster.rsa
+mkdir -p artifacts
+docker run \
+    --workdir=/go/src/github.com/cockroachdb/roachperf \
+    --volume="${GOPATH%%:*}/src":/go/src \
+    --volume="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)":/go/src/github.com/cockroachdb/roachperf \
+    --rm \
+    cockroachdb/builder:20170422-212842 ./run-nightly.sh


### PR DESCRIPTION
Add some test scripts for TeamCity. These are hooked up to the [Roachperf Nightly](https://teamcity.cockroachdb.com/viewType.html?buildTypeId=Cockroach_Nightlies_RoachperfNightly) TeamCity test and will get run every night.

I still need to have it upload the results to S3. For now it stores them in the TeamCity artifacts, which is definitely not sufficient for the long term.