### PR TITLE
Support roachprod.

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultHostDir = "${HOME}/.roachprod/hosts"
+)
+
+func loadClusters() error {
+	hd := os.ExpandEnv(defaultHostDir)
+	files, err := ioutil.ReadDir(hd)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if !file.Mode().IsRegular() {
+			continue
+		}
+
+		filename := filepath.Join(hd, file.Name())
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return errors.Wrapf(err, "could not read %s", filename)
+		}
+		lines := strings.Split(string(contents), "\n")
+
+		c := &cluster{
+			name: file.Name(),
+		}
+
+		for _, l := range lines {
+			if len(l) == 0 {
+				continue
+			}
+			parts := strings.Split(l, "@")
+			var n, u string
+			if len(parts) == 1 {
+				user, err := user.Current()
+				if err != nil {
+					return errors.Wrapf(err, "failed to lookup current user")
+				}
+				u = user.Username
+				n = parts[0]
+			} else if len(parts) == 2 {
+				u = parts[0]
+				n = parts[1]
+			} else {
+				return fmt.Errorf("invalid hosts line, expected <username>@<host>, got %q", l)
+			}
+
+			c.vms = append(c.vms, n)
+			c.users = append(c.users, u)
+		}
+		clusters[file.Name()] = c
+	}
+	return nil
+}

--- a/ssh.go
+++ b/ssh.go
@@ -20,13 +20,18 @@ import (
 
 var knownHosts ssh.HostKeyCallback
 var knownHostsOnce sync.Once
+var insecureIgnoreHostKey bool
 
 func getKnownHosts() ssh.HostKeyCallback {
 	knownHostsOnce.Do(func() {
 		var err error
-		knownHosts, err = knownhosts.New(filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts"))
-		if err != nil {
-			log.Fatal(err)
+		if insecureIgnoreHostKey {
+			knownHosts = ssh.InsecureIgnoreHostKey()
+		} else {
+			knownHosts, err = knownhosts.New(filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts"))
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	})
 	return knownHosts


### PR DESCRIPTION
This loads the list of clusters (and user/host names) from
`~/.roachprod/hosts`.

Some tweaks to how cluster details are stored.
Also ignore host keys checking by default since a new `roachprod`
cluster will likely never have been sshed into.