### PR TITLE
Use subdirectory of mounted volume for cockroach data dir

### DIFF
--- a/cockroach.go
+++ b/cockroach.go
@@ -27,7 +27,7 @@ func (r cockroach) start(c *cluster) {
 		} else {
 			args = append(args, "--insecure")
 		}
-		args = append(args, "--store=path=/mnt/data1")
+		args = append(args, "--store=path=/mnt/data1/cockroach")
 		args = append(args, "--logtostderr")
 		args = append(args, "--log-dir=")
 		args = append(args, "--background")


### PR DESCRIPTION
Chose `cockroach` instead of `cockroach-data` because it better
parallels the `cassandra` directory name that we use for cassandra, and
because the code for wiping already explicitly deletes
`/mnt/data1/cockroach` (but not `/mnt/data1/cockroach-data`).

Fixes https://github.com/cockroachlabs/roachprod/issues/17