### PR TITLE
Set --cache and --max-sql-memory to 25%, as recommended everywhere else

### DIFF
--- a/cockroach.go
+++ b/cockroach.go
@@ -31,8 +31,8 @@ func (r cockroach) start(c *cluster) {
 		args = append(args, "--logtostderr")
 		args = append(args, "--log-dir=")
 		args = append(args, "--background")
-		args = append(args, "--cache=50%")
-		args = append(args, "--max-sql-memory=10%")
+		args = append(args, "--cache=25%")
+		args = append(args, "--max-sql-memory=25%")
 		if join != host {
 			args = append(args, "--join="+join)
 		}


### PR DESCRIPTION
These are the values suggested in our docs, used in our prod clusters,
and the default in our orchestration configurations. If there's a reason
for them to be different here, I'd be interested to know.

Inspired by https://github.com/cockroachdb/cockroach/issues/19635#issuecomment-350077470