### PR TITLE
Introduce `geonightly` test

### DIFF
--- a/run-nightly.sh
+++ b/run-nightly.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [[ -z "${1}" ]]; then
+    echo "Test name not specified."
+    exit 1
+fi
+
+name=${1}
+shift
+
 cd ../../cockroachlabs/roachprod
 go install
 cd ../../cockroachdb/roachperf
@@ -16,7 +24,7 @@ echo $GOOGLE_CREDENTIALS > creds.json
 gcloud auth activate-service-account --key-file=creds.json
 
 # It might already exist.
-roachprod -u teamcity create nightly || roachprod sync
+roachprod -u teamcity create "$@" "${name}" || roachprod sync
 
 eval $(ssh-agent)
 ssh-add ~/.ssh/google_compute_engine
@@ -26,9 +34,9 @@ chmod +x cockroach
 curl -L https://edge-binaries.cockroachdb.com/loadgen/kv.LATEST -o kv
 chmod +x kv
 
-roachperf teamcity-nightly put ./cockroach ./cockroach
-roachperf teamcity-nightly put ./kv ./kv
+roachperf "teamcity-${name}" put ./cockroach ./cockroach
+roachperf "teamcity-${name}" put ./kv ./kv
 
 cd artifacts
-roachperf teamcity-nightly test nightly
+roachperf "teamcity-${name}" test nightly --duration 5s
 roachperf upload $(ls)

--- a/teamcity-nightly.sh
+++ b/teamcity-nightly.sh
@@ -10,4 +10,4 @@ docker run \
     --env="AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
     --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS}" \
     --rm \
-    cockroachdb/builder:20171004-085709 ./run-nightly.sh
+    cockroachdb/builder:20171004-085709 ./run-nightly.sh "$@"

--- a/tests.go
+++ b/tests.go
@@ -19,13 +19,14 @@ var duration time.Duration
 var concurrency string
 
 var tests = map[string]func(clusterName, dir string){
-	"kv_0":    kv0,
-	"kv_95":   kv95,
-	"ycsb_a":  ycsbA,
-	"ycsb_b":  ycsbB,
-	"ycsb_c":  ycsbC,
-	"nightly": nightly,
-	"splits":  splits,
+	"kv_0":       kv0,
+	"kv_95":      kv95,
+	"ycsb_a":     ycsbA,
+	"ycsb_b":     ycsbB,
+	"ycsb_c":     ycsbC,
+	"geonightly": geoNightly,
+	"nightly":    nightly,
+	"splits":     splits,
 }
 
 var dirRE = regexp.MustCompile(`([^.]+)\.`)
@@ -411,7 +412,15 @@ func ycsbC(clusterName, dir string) {
 	kvTest(clusterName, "ycsb_c", dir, "./ycsb --workload=C --splits=1000 --cassandra-replication=3")
 }
 
+func geoNightly(clusterName, dir string) {
+	generalNightly(clusterName, dir, "--duration=10h")
+}
+
 func nightly(clusterName, dir string) {
+	generalNightly(clusterName, dir, "--duration=10m")
+}
+
+func generalNightly(clusterName, dir string, extraArgs ...string) {
 	var existing *testMetadata
 	if dir != "" {
 		existing = &testMetadata{}
@@ -426,8 +435,8 @@ func nightly(clusterName, dir string) {
 		name string
 		cmd  string
 	}{
-		{"kv_0", "./kv --read-percent=0 --splits=1000 --concurrency=384 --duration=10m"},
-		{"kv_95", "./kv --read-percent=95 --splits=1000 --concurrency=384 --duration=10m"},
+		{"kv_0", "./kv --read-percent=0 --splits=1000 --concurrency=384 " + strings.Join(extraArgs, " ")},
+		{"kv_95", "./kv --read-percent=95 --splits=1000 --concurrency=384 " + strings.Join(extraArgs, " ")},
 		// TODO(tamird/petermattis): this configuration has been observed to hang
 		// indefinitely. Re-enable when it is more reliable.
 		//


### PR DESCRIPTION
This is intended to be run in nightly tests via teamcity-nightly.sh which has
been updated correspondingly.

For now, the `geonightly` test runs the `nightly` test with a longer duration on
a geo-distributed cluster, but this is just a starting point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachperf/19)
<!-- Reviewable:end -->
