### PR TITLE
Add support for a "local" cluster

### DIFF
--- a/cassandra.go
+++ b/cassandra.go
@@ -69,8 +69,17 @@ func (cassandra) start(c *cluster) {
 	})
 }
 
-func (cassandra) nodeURL(_ *cluster, host string) string {
-	return fmt.Sprintf("'cassandra://%s:9042'", host)
+func (cassandra) nodeURL(_ *cluster, host string, port int) string {
+	return fmt.Sprintf("'cassandra://%s:%d'", host, port)
+}
+
+func (cassandra) nodePort(c *cluster, index int) int {
+	if c.isLocal() {
+		// TODO(peter): This will require a bit of work to adjust ports in
+		// cassandra.yaml.
+		panic("unimplemented: local cassandra cluster")
+	}
+	return 9042
 }
 
 func makeCassandraYAML(c *cluster) (string, error) {

--- a/hosts.go
+++ b/hosts.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultHostDir = "${HOME}/.roachprod/hosts"
+	local          = "local"
 )
 
 func loadClusters() error {
@@ -62,6 +63,10 @@ func loadClusters() error {
 			c.users = append(c.users, u)
 		}
 		clusters[file.Name()] = c
+	}
+
+	clusters[local] = &cluster{
+		name: local,
 	}
 	return nil
 }


### PR DESCRIPTION
This allows using `roachperf` to start a local cluster instead of
`roachdemo`. The `start`, `stop`, `wipe`, `status` and `pgurl` commands
work, but `test` does not. That will be fixed in a follow-on change.