### PR TITLE
Learn to parse comments and localities from hosts files

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -21,10 +21,11 @@ type clusterImpl interface {
 }
 
 type cluster struct {
-	// name, vms, users are populated at init time.
-	name  string
-	vms   []string
-	users []string
+	// name, vms, users, localities are populated at init time.
+	name       string
+	vms        []string
+	users      []string
+	localities []string
 	// all other fields are populated in newCluster.
 	nodes   []int
 	loadGen int
@@ -40,6 +41,10 @@ func (c *cluster) host(index int) string {
 
 func (c *cluster) user(index int) string {
 	return c.users[index-1]
+}
+
+func (c *cluster) locality(index int) string {
+	return c.localities[index-1]
 }
 
 func (c *cluster) isLocal() bool {

--- a/cockroach.go
+++ b/cockroach.go
@@ -47,6 +47,9 @@ func (r cockroach) start(c *cluster) {
 		args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", cache))
 		args = append(args, fmt.Sprintf("--port=%d", port))
 		args = append(args, fmt.Sprintf("--http-port=%d", port+1))
+		if locality := c.locality(nodes[i]); locality != "" {
+			args = append(args, "--locality="+locality)
+		}
 		if nodes[i] != 1 {
 			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.nodePort(c, 1)))
 		}

--- a/main.go
+++ b/main.go
@@ -175,6 +175,7 @@ func newCluster(name string, reserveLoadGen bool) (*cluster, error) {
 
 		c.vms = make([]string, max+1)
 		c.users = make([]string, max+1)
+		c.localities = make([]string, max+1)
 		for i := range c.vms {
 			c.vms[i] = "localhost"
 			c.users[i] = user.Username


### PR DESCRIPTION
Hosts files can now include comment lines and locality metadata. For
example:

    # This is a comment.
    benesch@12.34.56.78  region=us-east4,zone=us-east4-a

The second field is a locality specification that will be passed to
the --locality argument of cockroach start.

See also: cockroachlabs/roachprod#24, cockroachlabs/production#537